### PR TITLE
Make "role" optional

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -7,6 +7,4 @@ configuration:
   properties:
     role:
       type: string
-  required:
-    - role
   additionalProperties: false


### PR DESCRIPTION
This will allow the environment variable configuration to work when `role:` is omitted