### PR TITLE
Fix Broken Tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.4'
 services:
   tests:
-    image: buildkite/plugin-tester
+    image: buildkite/plugin-tester:latest@sha256:708ad19f7b52c43b8958a49d316271ca8fe988dd52d66971af6c0b8678b6627b
     volumes:
       - ".:/plugin"


### PR DESCRIPTION
Buildkite Plugin Tester has just been updated 3 days ago, let's update our tag so that we don't
unexpectedly break our builds